### PR TITLE
Fixing `main` entry in package.json file

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
         "type": "git",
         "url": "git+https://github.com/L3bowski/cucumber-steps-parser.git"
     },
-    "main": "src/index.ts",
+    "main": "dist/index.js",
     "bin": {
         "cucumber-steps-parser": "./bin/cucumber-steps-parser"
     },


### PR DESCRIPTION
The `main` property of the package file incorrectly pointed at the source file instead of the dist directory making any integration impossible.